### PR TITLE
Use some fancy trickery with hasattr() to automatically select the appropriate HIDButtons element

### DIFF
--- a/gamepad.py
+++ b/gamepad.py
@@ -2,6 +2,7 @@ print("please wait...")
 import sys, time
 from TPPFLUSH.tppflush import *
 import pygame
+from enum import IntEnum
 
 done=False
 
@@ -23,7 +24,7 @@ buttonMappings = [
                 HIDButtons.DPADRIGHT
         ]
 
-class KBDButtons(int):
+class KBDButtons(IntEnum):
         C_UP = pygame.K_w
         C_DOWN = pygame.K_s
         C_LEFT = pygame.K_a
@@ -47,6 +48,8 @@ class KBDButtons(int):
 
         HOME = pygame.K_HOME
         POWER = pygame.K_END
+
+dpad_name_map = {"D_UP": "DPADUP", "D_LEFT": "DPADLEFT","D_DOWN":"DPADDOWN","D_RIGHT":"DPADRIGHT"} #map from name in KBDButtons to name in HIDButtons
 
 if len(sys.argv) < 2:
 	server = input("3DS IP >").strip()
@@ -113,50 +116,24 @@ while done==False:
                         if event.key == KBDButtons.C_RIGHT:
                                 server.circle_pad_set(CPAD_Commands.CPADRIGHT)
                                 #print("C_RIGHT")
-                                
-                        if event.key == KBDButtons.D_UP:
-                                server.hid_press(HIDButtons.DPADUP)
-                                #print("UP")
-                        if event.key == KBDButtons.D_LEFT:
-                                server.hid_press(HIDButtons.DPADLEFT)
-                                #print("LEFT")
-                        if event.key == KBDButtons.D_DOWN:
-                                server.hid_press(HIDButtons.DPADDOWN)
-                                #print("DOWN")
-                        if event.key == KBDButtons.D_RIGHT:
-                                server.hid_press(HIDButtons.DPADRIGHT)
-                                #print("RIGHT")
-                                
-                        if event.key == KBDButtons.B: #b
-                                server.hid_press(HIDButtons.B)
-                                #print("B")
-                        if event.key == KBDButtons.A: #a
-                                server.hid_press(HIDButtons.A)
-                                #print("A")
-                        if event.key == KBDButtons.Y: #y
-                                server.hid_press(HIDButtons.Y)
-                                #print("Y")
-                        if event.key == KBDButtons.X: #x
-                                server.hid_press(HIDButtons.X)
-                                #print("X")
-                        if event.key == KBDButtons.L: #l
-                                server.hid_press(HIDButtons.L)
-                                #print("L")
-                        if event.key == KBDButtons.R: #r
-                                server.hid_press(HIDButtons.R)
-                                #print("R")
+
+                        for button in KBDButtons:
+                            if event.key == button:
+                                if hasattr(HIDButtons, button.name): #KBDButtons.B -> HIDButtons.B
+                                        server.press(HIDButtons[button])
+                                        #print(button.name)
+
+                                #dpadbuttons have a different name in HIDButtons
+                                if button.name in dpad_name_map.keys():
+                                        server.press(HIDButtons[dpad_name_map[button.name]])
+                                        #print(button.name)
+
                         if event.key == KBDButtons.ZL: #zl
                                 server.n3ds_zlzr_press(N3DS_Buttons.ZL)
                                 #print("ZL")
                         if event.key == KBDButtons.ZR: #zr
                                 server.n3ds_zlzr_press(N3DS_Buttons.ZR)
                                 #print("ZR")
-                        if event.key == KBDButtons.START: #st
-                                server.hid_press(HIDButtons.START)
-                                #print("START")
-                        if event.key == KBDButtons.SELECT: #sl
-                                server.hid_press(HIDButtons.SELECT)
-                                #print("SELECT")
                         if event.key == KBDButtons.HOME: #home
                                 server.special_press(Special_Buttons.HOME)
                                 #print("HOME")
@@ -170,15 +147,6 @@ while done==False:
                         server.send(print_bytes)
                         
                 elif event.type == pygame.KEYUP:
-                        if event.key == KBDButtons.D_UP:
-                                server.hid_unpress(HIDButtons.DPADUP)
-                        if event.key == KBDButtons.D_LEFT:
-                                server.hid_unpress(HIDButtons.DPADLEFT)
-                        if event.key == KBDButtons.D_DOWN:
-                                server.hid_unpress(HIDButtons.DPADDOWN)
-                        if event.key == KBDButtons.D_RIGHT:
-                                server.hid_unpress(HIDButtons.DPADRIGHT)
-
                         if event.key == KBDButtons.C_UP:
                                 server.circle_pad_coords[1] = 0
                         if event.key == KBDButtons.C_LEFT:
@@ -188,30 +156,24 @@ while done==False:
                         if event.key == KBDButtons.C_RIGHT:
                                 server.circle_pad_coords[0] = 0
                         
-                        if event.key == KBDButtons.B: #b
-                                server.hid_unpress(HIDButtons.B)
-                        if event.key == KBDButtons.A: #a
-                                server.hid_unpress(HIDButtons.A)
-                        if event.key == KBDButtons.Y: #y
-                                server.hid_unpress(HIDButtons.Y)
-                        if event.key == KBDButtons.X: #x
-                                server.hid_unpress(HIDButtons.X)
-                        if event.key == KBDButtons.L: #l
-                                server.hid_unpress(HIDButtons.L)
-                        if event.key == KBDButtons.R: #r
-                                server.hid_unpress(HIDButtons.R)
+                        for button in KBDButtons:
+                            if event.key == button:
+                                if hasattr(HIDButtons, button.name): #KBDButtons.B -> HIDButtons.B
+                                        server.unpress(HIDButtons[button])
+
+                                #dpadbuttons have a different name in HIDButtons
+                                if button.name in dpad_name_map.keys():
+                                        server.unpress(HIDButtons[dpad_name_map[button.name]])
+
                         if event.key == KBDButtons.ZL: #zl
                                 server.n3ds_zlzr_unpress(N3DS_Buttons.ZL)
                         if event.key == KBDButtons.ZR: #zr
                                 server.n3ds_zlzr_unpress(N3DS_Buttons.ZR)
-                        if event.key == KBDButtons.START: #st
-                                server.hid_unpress(HIDButtons.START)
-                        if event.key == KBDButtons.SELECT: #sl
-                                server.hid_unpress(HIDButtons.SELECT)
                         if event.key == KBDButtons.HOME: #hm
                                 server.special_unpress(Special_Buttons.HOME)
                         if event.key == KBDButtons.POWER: #pw
                                 server.special_unpress(Special_Buttons.POWER)
+
                         server.send(print_bytes)
 
                 # Possible joystick actions: JOYAXISMOTION JOYBALLMOTION JOYBUTTONDOWN JOYBUTTONUP JOYHATMOTION

--- a/gamepad.py
+++ b/gamepad.py
@@ -30,10 +30,10 @@ class KBDButtons(IntEnum):
         C_LEFT = pygame.K_a
         C_RIGHT = pygame.K_d
 
-        D_UP = pygame.K_UP
-        D_DOWN = pygame.K_DOWN
-        D_LEFT = pygame.K_LEFT
-        D_RIGHT = pygame.K_RIGHT
+        DPADUP = pygame.K_UP
+        DPADDOWN = pygame.K_DOWN
+        DPADLEFT = pygame.K_LEFT
+        DPADRIGHT = pygame.K_RIGHT
 
         A = pygame.K_j
         B = pygame.K_k
@@ -48,8 +48,6 @@ class KBDButtons(IntEnum):
 
         HOME = pygame.K_HOME
         POWER = pygame.K_END
-
-dpad_name_map = {"D_UP": "DPADUP", "D_LEFT": "DPADLEFT","D_DOWN":"DPADDOWN","D_RIGHT":"DPADRIGHT"} #map from name in KBDButtons to name in HIDButtons
 
 if len(sys.argv) < 2:
 	server = input("3DS IP >").strip()
@@ -120,12 +118,7 @@ while done==False:
                         for button in KBDButtons:
                             if event.key == button:
                                 if hasattr(HIDButtons, button.name): #KBDButtons.B -> HIDButtons.B
-                                        server.press(HIDButtons[button])
-                                        #print(button.name)
-
-                                #dpadbuttons have a different name in HIDButtons
-                                if button.name in dpad_name_map.keys():
-                                        server.press(HIDButtons[dpad_name_map[button.name]])
+                                        server.press(HIDButtons[button.name])
                                         #print(button.name)
 
                         if event.key == KBDButtons.ZL: #zl
@@ -159,11 +152,7 @@ while done==False:
                         for button in KBDButtons:
                             if event.key == button:
                                 if hasattr(HIDButtons, button.name): #KBDButtons.B -> HIDButtons.B
-                                        server.unpress(HIDButtons[button])
-
-                                #dpadbuttons have a different name in HIDButtons
-                                if button.name in dpad_name_map.keys():
-                                        server.unpress(HIDButtons[dpad_name_map[button.name]])
+                                        server.unpress(HIDButtons[button.name])
 
                         if event.key == KBDButtons.ZL: #zl
                                 server.n3ds_zlzr_unpress(N3DS_Buttons.ZL)


### PR DESCRIPTION
This just makes the code a bit shorter.

Making KBDButtons an IntEnum allows one to use "for button in KBDButtons", which is rather convenient. It also allows programmatically checking for the name of a given element.

If HIDButtons.B exists, hasattr(HIDButtons, 'B') returns true. This is then used to ensure only elements of HIDButtons that exist are pressed.

Since KBDButtons uses the name D_UP while HIDButtons uses DPADUP, I introduce a dict named dpad_name_map to keep track of the differences. That way I can check to see if the button's name is part of that dict, and if so, use the HIDButtons name for that element.

You may want to test this with a gamecube controller before accepting this PR.

Congratulations on a successful release!